### PR TITLE
Log only job ID, not entire job

### DIFF
--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -75,7 +75,7 @@ defmodule Rihanna.JobDispatcher do
 
   defp spawn_supervised_task(job) do
     Task.Supervisor.async_nolink(@task_supervisor, fn ->
-      Rihanna.Logger.log(:debug, fn -> "[Rihanna] Starting job #{inspect(job)}" end)
+      Rihanna.Logger.log(:debug, fn -> "[Rihanna] Starting job #{job.id}" end)
       case job.term do
         {mod, fun, args} ->
           # It's a simple MFA
@@ -88,7 +88,7 @@ defmodule Rihanna.JobDispatcher do
           # Assume that mod conforms to Rihanna.Job behaviour
           apply(mod, :perform, [arg])
       end
-      Rihanna.Logger.log(:debug, fn -> "[Rihanna] Finished job #{inspect(job)}" end)
+      Rihanna.Logger.log(:debug, fn -> "[Rihanna] Finished job #{job.id}" end)
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rihanna.MixProject do
   def project do
     [
       app: :rihanna,
-      version: "0.5.2",
+      version: "0.5.3",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- Jobs can contain sensitive information