### PR TITLE
Add a startup delay

### DIFF
--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -2,6 +2,7 @@ defmodule Rihanna.JobDispatcher do
   use GenServer
 
   @task_supervisor Rihanna.TaskSupervisor
+  @startup_delay if Mix.env == :test, do: 0, else: :timer.seconds(5)
 
   @moduledoc false
 
@@ -20,7 +21,9 @@ defmodule Rihanna.JobDispatcher do
 
     state = %{working: %{}, pg: pg}
 
-    Process.send(self(), :poll, [])
+    # Use a startup delay to avoid killing the supervisor if we can't connect
+    # to the database for some reason.
+    Process.send_after(self(), :poll, @startup_delay)
     {:ok, state}
   end
 


### PR DESCRIPTION
- This means Rihanna will continue retrying to connect to the database
instaed of terminating the entire app