### PR TITLE
Add optional callback to jobs which defines what to do on error of job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.0.0
+
+### Added
+
+- Added an optional callback per job which defines what to do when that job errors.
+
+  ```elixir
+  def after_error(failure_reason, args) do
+    notify_someone(__MODULE__, failure_reason, args)
+  end
+  ```
+
 ## v0.7.0
 
 ### Added

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,1 @@
+:0: Unknown type 'Elixir.Access':get/2

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rihanna.MixProject do
   def project do
     [
       app: :rihanna,
-      version: "0.7.2",
+      version: "1.0.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Rihanna.MixProject do
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"],
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       docs: [

--- a/test/rihanna/job_test.exs
+++ b/test/rihanna/job_test.exs
@@ -2,6 +2,7 @@ defmodule Rihanna.JobTest do
   use ExUnit.Case, async: false
   import Rihanna.Job
   import TestHelper
+  doctest Rihanna.Job
 
   @class_id Rihanna.Config.pg_advisory_lock_class_id()
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -41,7 +41,11 @@ defmodule Rihanna.Mocks do
 
     def perform([pid, msg]) do
       Process.send(pid, {msg, self()}, [])
-      {:error, "failed for some reason"}
+      {:error, %{message: "failed for some reason"}}
+    end
+
+    def after_error({:error, _}, [pid, _]) do
+      Process.send(pid, "After error callback", [])
     end
   end
 
@@ -50,7 +54,11 @@ defmodule Rihanna.Mocks do
 
     def perform([pid, msg]) do
       Process.send(pid, {msg, self()}, [])
-      {:error, "failed for some reason"}
+      :error
+    end
+
+    def after_error(:error, [pid, _]) do
+      Process.send(pid, "After error callback", [])
     end
   end
 
@@ -66,6 +74,10 @@ defmodule Rihanna.Mocks do
     def perform(_) do
       raise "Kaboom!"
     end
+
+    def after_error(_reason, [pid, _]) do
+      Process.send(pid, "After error callback", [])
+    end
   end
 
   defmodule MockJob do
@@ -73,6 +85,15 @@ defmodule Rihanna.Mocks do
 
     def perform(arg) do
       {:ok, arg}
+    end
+  end
+
+  defmodule ErrorBehaviourMockWithNoErrorCallback do
+    @behaviour Rihanna.Job
+
+    def perform([pid, msg]) do
+      Process.send(pid, {msg, self()}, [])
+      :error
     end
   end
 end


### PR DESCRIPTION
This runs for all three types of errors (tuple, atom or raised error)
but only runs for jobs which follow the behaviour rather than custom
jobs.