### PR TITLE
fix: update table name on create index

### DIFF
--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -135,7 +135,7 @@ defmodule Rihanna.Migration do
       ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (id);
       """,
       """
-      CREATE INDEX rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
+      CREATE INDEX rihanna_jobs_enqueued_at_id ON #{table_name} (enqueued_at ASC, id ASC);
       """
     ]
   end


### PR DESCRIPTION
This fails for me with a custom table name. The create index instruction is using rihanna_jobs.

```
** (Postgrex.Error) ERROR 42P01 (undefined_table): relation "rihanna_jobs" does not exist
    (ecto) lib/ecto/adapters/sql.ex:200: Ecto.Adapters.SQL.query!/5
    (ecto) lib/ecto/adapters/postgres.ex:96: anonymous fn/4 in Ecto.Adapters.Postgres.execute_ddl/3
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/adapters/postgres.ex:96: Ecto.Adapters.Postgres.execute_ddl/3
    (ecto) lib/ecto/migration/runner.ex:104: anonymous fn/2 in Ecto.Migration.Runner.flush/0
    (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/migration/runner.ex:102: Ecto.Migration.Runner.flush/0
    (stdlib) timer.erl:181: :timer.tc/2
```