### PR TITLE
Rescue after_error callback errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.2
+
+- Rescue after_error callback errors to stop a potential infinite retry loop
+  for a job.
+
 ## v1.2.1
 
 - Schedule and enqueue functions now raise errors with greater detail when

--- a/lib/rihanna/job.ex
+++ b/lib/rihanna/job.ex
@@ -356,7 +356,11 @@ defmodule Rihanna.Job do
   def after_error(job_module, reason, arg) do
     if :erlang.function_exported(job_module, :after_error, 2) do
       # If they implemented the behaviour, there will only ever be one arg
-      job_module.after_error(reason, arg)
+      try do
+        job_module.after_error(reason, arg)
+      rescue
+        _ -> :noop
+      end
     end
   end
 

--- a/lib/rihanna/job.ex
+++ b/lib/rihanna/job.ex
@@ -359,7 +359,23 @@ defmodule Rihanna.Job do
       try do
         job_module.after_error(reason, arg)
       rescue
-        _ -> :noop
+        exception ->
+          Logger.warn(
+            """
+            [Rihanna] After error callback failed
+            Got an unexpected error while trying to run the `after_error` callback.
+            Check your `#{inspect(job_module)}.after_error/2` callback and make sure it doesn’t raise.
+            Exception: #{inspect(exception)}
+            Arg1: #{inspect(reason)}
+            Arg2: #{inspect(arg)}
+            """,
+            exception: exception,
+            job_arguments: arg,
+            job_failure_reason: reason,
+            job_module: job_module
+          )
+
+          :noop
       end
     end
   end

--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -80,8 +80,8 @@ defmodule Rihanna.JobDispatcher do
 
   defp job_raised(%{id: id, term: {job_module, arg}}, reason, pg) do
     # NOTE: Do we need to demonitor here?
-    Rihanna.Job.after_error(job_module, reason, arg)
     Rihanna.Job.mark_failed(pg, id, DateTime.utc_now(), Exception.format_exit(reason))
+    Rihanna.Job.after_error(job_module, reason, arg)
   end
 
   defp job_raised(job, reason, pg) do
@@ -91,14 +91,14 @@ defmodule Rihanna.JobDispatcher do
 
   defp job_failure(%{id: id, term: {job_module, arg}}, reason, pg) do
     # NOTE: Do we need to demonitor here?
-    Rihanna.Job.after_error(job_module, reason, arg)
-
     Rihanna.Job.mark_failed(
       pg,
       id,
       DateTime.utc_now(),
       "Job Failed\n#{inspect(reason, limit: :infinity)}"
     )
+
+    Rihanna.Job.after_error(job_module, reason, arg)
   end
 
   defp job_failure(job, reason, pg) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rihanna.MixProject do
   def project do
     [
       app: :rihanna,
-      version: "1.2.1",
+      version: "1.2.2",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -62,6 +62,31 @@ defmodule Rihanna.Mocks do
     end
   end
 
+  defmodule ErrorBehaviourWithBadAfterErrorMock do
+    @behaviour Rihanna.Job
+
+    def perform([pid, msg]) do
+      Process.send(pid, {msg, self()}, [])
+      :error
+    end
+
+    def after_error(:error, [pid, _]) do
+      raise "Kaboom!"
+    end
+  end
+
+  defmodule BadBehaviourWithBadAfterErrorMock do
+    @behaviour Rihanna.Job
+
+    def perform(_) do
+      raise "Kaboom!"
+    end
+
+    def after_error(_reason, _args) do
+      raise "Double kaboom!"
+    end
+  end
+
   defmodule MFAMock do
     def fun(pid, msg) do
       Process.send(pid, {msg, self()}, [])


### PR DESCRIPTION
If a job fails currently, it attempts an `after_error/2` callback.

If that callback exists it is run. If it doesn't the dispatcher moves
on.

This commit handles the case where the callback is there, but it raises
an error. Previously if this happened, the dispatcher would die and the
job would be put back on the queue and picked up again when a new
dispatcher was created.