### PR TITLE
Make startup delay configurable

### DIFF
--- a/lib/rihanna/config.ex
+++ b/lib/rihanna/config.ex
@@ -149,4 +149,18 @@ defmodule Rihanna.Config do
   def producer_postgres_connection_supplied? do
     Application.get_env(:rihanna, :producer_postgres_connection, false)
   end
+
+  @doc """
+  # Use a startup delay to avoid killing the supervisor if we can't connect
+  # to the database for some reason. Value is in milliseconds.
+
+  # Defaults to 0 for test env and 5000ms for other envs.
+  """
+  def startup_delay do
+    Application.get_env(
+      :rihanna,
+      :startup_delay,
+      if(Mix.env() == :test, do: 0, else: :timer.seconds(5))
+    )
+  end
 end

--- a/lib/rihanna/config.ex
+++ b/lib/rihanna/config.ex
@@ -151,10 +151,16 @@ defmodule Rihanna.Config do
   end
 
   @doc """
-  # Use a startup delay to avoid killing the supervisor if we can't connect
-  # to the database for some reason. Value is in milliseconds.
+  Use a startup delay to avoid killing the supervisor if we can't connect
+  to the database for some reason. Value is in milliseconds.
 
-  # Defaults to 0 for test env and 5000ms for other envs.
+  Defaults to 0 for test env and 5000ms for other envs.
+
+  ## Example
+
+  ```
+  config :rihanna, startup_delay: :timer.milliseconds(500)
+  ```
   """
   def startup_delay do
     Application.get_env(

--- a/lib/rihanna/config.ex
+++ b/lib/rihanna/config.ex
@@ -19,6 +19,9 @@ defmodule Rihanna.Config do
   config :rihanna, jobs_table_name: "my_jobs"
   ```
   """
+
+  @default_startup_delay if(Mix.env() == :test, do: 0, else: :timer.seconds(5))
+
   def jobs_table_name() do
     Application.get_env(:rihanna, :jobs_table_name, "rihanna_jobs")
   end
@@ -166,7 +169,7 @@ defmodule Rihanna.Config do
     Application.get_env(
       :rihanna,
       :startup_delay,
-      if(Mix.env() == :test, do: 0, else: :timer.seconds(5))
+      @default_startup_delay
     )
   end
 end

--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -2,7 +2,6 @@ defmodule Rihanna.JobDispatcher do
   use GenServer
 
   @task_supervisor Rihanna.TaskSupervisor
-  @startup_delay if Mix.env() == :test, do: 0, else: :timer.seconds(5)
 
   @moduledoc false
 
@@ -13,7 +12,7 @@ defmodule Rihanna.JobDispatcher do
   @doc false
   def init(config) do
     db = Keyword.get(config, :db)
-    startup_delay = Keyword.get(config, :startup_delay, @startup_delay)
+    startup_delay = Rihanna.Config.startup_delay()
 
     # NOTE: These are linked because it is important that the pg session is also
     # killed if the JobDispatcher dies since otherwise we may leave dangling

--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -12,7 +12,7 @@ defmodule Rihanna.JobDispatcher do
   @doc false
   def init(config) do
     db = Keyword.get(config, :db)
-    startup_delay = Rihanna.Config.startup_delay()
+    startup_delay = Keyword.get(config, :startup_delay, Rihanna.Config.startup_delay())
 
     # NOTE: These are linked because it is important that the pg session is also
     # killed if the JobDispatcher dies since otherwise we may leave dangling

--- a/lib/rihanna/job_dispatcher.ex
+++ b/lib/rihanna/job_dispatcher.ex
@@ -7,13 +7,14 @@ defmodule Rihanna.JobDispatcher do
   @moduledoc false
 
   def start_link(config, opts) do
-    db = Keyword.get(config, :db)
-
-    GenServer.start_link(__MODULE__, db, opts)
+    GenServer.start_link(__MODULE__, config, opts)
   end
 
   @doc false
-  def init(db) do
+  def init(config) do
+    db = Keyword.get(config, :db)
+    startup_delay = Keyword.get(config, :startup_delay, @startup_delay)
+
     # NOTE: These are linked because it is important that the pg session is also
     # killed if the JobDispatcher dies since otherwise we may leave dangling
     # locks in the zombie pg process
@@ -23,7 +24,7 @@ defmodule Rihanna.JobDispatcher do
 
     # Use a startup delay to avoid killing the supervisor if we can't connect
     # to the database for some reason.
-    Process.send_after(self(), :initialise, @startup_delay)
+    Process.send_after(self(), :initialise, startup_delay)
     {:ok, state}
   end
 


### PR DESCRIPTION
The startup delay is currently dependent on compile time Mix configuration. Because dependencies are always compiled in `:prod`, this means that this `startup_delay` will default to 5 seconds even in test envs. This PR makes this runtime configurable, so you can initialize it in your test env with a lower value, for example like this:

```
setup do
    {:ok, _} =
      start_supervised({
        Rihanna.Supervisor,
        [postgrex: Repo.config(), startup_delay: 0, name: Rihanna.Supervisor]
      })
...
```