### PR TITLE
Allow setting the priority of a job

### DIFF
--- a/lib/rihanna/job.ex
+++ b/lib/rihanna/job.ex
@@ -91,10 +91,9 @@ defmodule Rihanna.Job do
   @doc """
   The priority of this job.
 
-  Conforms to the niceness values used in Linux processes — lower values
-  are more important.
+  A higher value means a higher job priority. Has a default of 0.
   """
-  def priority, do: 19
+  def priority, do: 0
 
   @doc false
   def enqueue(term, due_at \\ nil) do
@@ -263,7 +262,7 @@ defmodule Rihanna.Job do
           WHERE NOT (id = ANY($3))
           AND (due_at IS NULL OR due_at <= now())
           AND failed_at IS NULL
-          ORDER BY priority, enqueued_at, j.id
+          ORDER BY priority DESC, enqueued_at, j.id
           FOR UPDATE OF j SKIP LOCKED
           LIMIT 1
         ) AS t1
@@ -277,7 +276,7 @@ defmodule Rihanna.Job do
               AND (due_at IS NULL OR due_at <= now())
               AND failed_at IS NULL
               AND (j.enqueued_at, j.id) > (jobs.enqueued_at, jobs.id)
-              ORDER BY priority, enqueued_at, j.id
+              ORDER BY priority DESC, enqueued_at, j.id
               FOR UPDATE OF j SKIP LOCKED
               LIMIT 1
             ) AS j

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -136,7 +136,7 @@ defmodule Rihanna.Migration do
       ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (id);
       """,
       """
-      CREATE INDEX #{table_name}_enqueued_at_id ON #{table_name} (priority ASC, enqueued_at ASC, id ASC);
+      CREATE INDEX #{table_name}_priority_enqueued_at_id ON #{table_name} (priority ASC, enqueued_at ASC, id ASC);
       """
     ]
   end
@@ -233,7 +233,7 @@ defmodule Rihanna.Migration do
         :ok
     end
 
-    required_indexes = ["#{table_name}_pkey", "#{table_name}_enqueued_at_id"]
+    required_indexes = ["#{table_name}_pkey", "#{table_name}_priority_enqueued_at_id"]
 
     case Postgrex.query(
            pg,

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -104,7 +104,7 @@ defmodule Rihanna.Migration do
       CREATE TABLE #{table_name} (
         id int NOT NULL,
         term bytea NOT NULL,
-        priority integer NOT NULL DEFAULT 19,
+        priority integer NOT NULL DEFAULT 0,
         enqueued_at timestamp with time zone NOT NULL,
         due_at timestamp with time zone,
         failed_at timestamp with time zone,
@@ -136,7 +136,7 @@ defmodule Rihanna.Migration do
       ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (id);
       """,
       """
-      CREATE INDEX #{table_name}_priority_enqueued_at_id ON #{table_name} (priority ASC, enqueued_at ASC, id ASC);
+      CREATE INDEX #{table_name}_priority_enqueued_at_id ON #{table_name} (priority DESC, enqueued_at ASC, id ASC);
       """
     ]
   end

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -104,6 +104,7 @@ defmodule Rihanna.Migration do
       CREATE TABLE #{table_name} (
         id int NOT NULL,
         term bytea NOT NULL,
+        priority integer NOT NULL DEFAULT 19,
         enqueued_at timestamp with time zone NOT NULL,
         due_at timestamp with time zone,
         failed_at timestamp with time zone,

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -213,7 +213,7 @@ defmodule Rihanna.Migration do
   @doc false
   # Check that the required upgrades have been added
   def check_upgrade_not_required!(pg) do
-    required_upgrade_columns = ["due_at", "rihanna_internal_meta"]
+    required_upgrade_columns = ["due_at", "rihanna_internal_meta", "priority"]
     table_name = Rihanna.Job.table()
 
     case Postgrex.query(

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -136,7 +136,7 @@ defmodule Rihanna.Migration do
       ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (id);
       """,
       """
-      CREATE INDEX #{table_name}_enqueued_at_id ON #{table_name} (enqueued_at ASC, id ASC);
+      CREATE INDEX #{table_name}_enqueued_at_id ON #{table_name} (priority ASC, enqueued_at ASC, id ASC);
       """
     ]
   end

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -79,7 +79,7 @@ defmodule Rihanna.Migration.Upgrade do
       """
       DO $$
           BEGIN
-              DROP INDEX IF EXISTS rihanna_jobs_enqueued_at_id;
+              DROP INDEX IF EXISTS rihanna_jobs_priority_enqueued_at_id;
               CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
           END;
       $$
@@ -135,7 +135,7 @@ defmodule Rihanna.Migration.Upgrade do
       DO $$
           BEGIN
               DROP INDEX IF EXISTS rihanna_jobs_enqueued_at_id;
-              CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (priority ASC, enqueued_at ASC, id ASC);
+              CREATE INDEX IF NOT EXISTS rihanna_jobs_priority_enqueued_at_id ON rihanna_jobs (priority ASC, enqueued_at ASC, id ASC);
           END;
       $$
       """

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -131,7 +131,7 @@ defmodule Rihanna.Migration.Upgrade do
       """
       DO $$
           BEGIN
-              ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 19;
+              ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 0;
           EXCEPTION
               WHEN duplicate_column THEN
               RAISE NOTICE 'column already exists in #{table_name}.';
@@ -142,7 +142,7 @@ defmodule Rihanna.Migration.Upgrade do
       DO $$
           BEGIN
               DROP INDEX IF EXISTS rihanna_jobs_enqueued_at_id;
-              CREATE INDEX IF NOT EXISTS rihanna_jobs_priority_enqueued_at_id ON rihanna_jobs (priority ASC, enqueued_at ASC, id ASC);
+              CREATE INDEX IF NOT EXISTS rihanna_jobs_priority_enqueued_at_id ON rihanna_jobs (priority DESC, enqueued_at ASC, id ASC);
           END;
       $$
       """

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -72,6 +72,9 @@ defmodule Rihanna.Migration.Upgrade do
       """,
       """
       ALTER TABLE #{table_name} DROP COLUMN rihanna_internal_meta;
+      """,
+      """
+      ALTER TABLE #{table_name} DROP COLUMN priority;
       """
     ]
   end
@@ -116,6 +119,9 @@ defmodule Rihanna.Migration.Upgrade do
       """,
       """
       CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
+      """,
+      """
+      ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 19;
       """
     ]
   end

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -75,6 +75,14 @@ defmodule Rihanna.Migration.Upgrade do
       """,
       """
       ALTER TABLE #{table_name} DROP COLUMN priority;
+      """,
+      """
+      DO $$
+          BEGIN
+              DROP INDEX IF EXISTS rihanna_jobs_enqueued_at_id;
+              CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
+          END;
+      $$
       """
     ]
   end
@@ -122,6 +130,14 @@ defmodule Rihanna.Migration.Upgrade do
       """,
       """
       ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 19;
+      """,
+      """
+      DO $$
+          BEGIN
+              DROP INDEX IF EXISTS rihanna_jobs_enqueued_at_id;
+              CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (priority ASC, enqueued_at ASC, id ASC);
+          END;
+      $$
       """
     ]
   end

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -129,7 +129,14 @@ defmodule Rihanna.Migration.Upgrade do
       CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
       """,
       """
-      ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 19;
+      DO $$
+          BEGIN
+              ALTER TABLE #{table_name} ADD COLUMN priority integer NOT NULL DEFAULT 19;
+          EXCEPTION
+              WHEN duplicate_column THEN
+              RAISE NOTICE 'column already exists in #{table_name}.';
+          END;
+      $$
       """,
       """
       DO $$

--- a/test/rihanna/job_test.exs
+++ b/test/rihanna/job_test.exs
@@ -105,7 +105,7 @@ defmodule Rihanna.JobTest do
     test "locks all available jobs, ordered with the highest priority first", %{pg: pg} do
       insert_job(pg, :ready_to_run_highest_priority)
 
-      [ first_job | _rest ] = lock(pg, 5)
+      [first_job | _rest] = lock(pg, 5)
 
       assert %Rihanna.Job{priority: -19} = first_job
     end

--- a/test/rihanna/job_test.exs
+++ b/test/rihanna/job_test.exs
@@ -107,7 +107,7 @@ defmodule Rihanna.JobTest do
 
       [first_job | _rest] = lock(pg, 5)
 
-      assert %Rihanna.Job{priority: -19} = first_job
+      assert %Rihanna.Job{priority: 1} = first_job
     end
 
     test "locks all available jobs if equal to N", %{pg: pg, jobs: jobs} do

--- a/test/rihanna/job_test.exs
+++ b/test/rihanna/job_test.exs
@@ -102,6 +102,14 @@ defmodule Rihanna.JobTest do
       assert length(locked) == 3
     end
 
+    test "locks all available jobs, ordered with the highest priority first", %{pg: pg} do
+      insert_job(pg, :ready_to_run_highest_priority)
+
+      [ first_job | _rest ] = lock(pg, 5)
+
+      assert %Rihanna.Job{priority: -19} = first_job
+    end
+
     test "locks all available jobs if equal to N", %{pg: pg, jobs: jobs} do
       locked = lock(pg, 3)
 

--- a/test/rihanna_test.exs
+++ b/test/rihanna_test.exs
@@ -20,7 +20,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
-      assert job.priority == 19
+      assert job.priority == 0
       assert job.term == @term
     end
 
@@ -34,7 +34,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
-      assert job.priority == 19
+      assert job.priority == 0
       assert job.term == @term
     end
 
@@ -69,7 +69,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
-      assert job.priority == 19
+      assert job.priority == 0
       assert job.term == {Rihanna.Mocks.MockJob, :arg}
     end
 
@@ -83,7 +83,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
-      assert job.priority == 19
+      assert job.priority == 0
       assert job.term == {Rihanna.Mocks.MockJob, :arg}
     end
 
@@ -126,7 +126,7 @@ defmodule RihannaTest do
           assert job.due_at |> is_nil
           assert job.fail_reason |> is_nil
           assert job.failed_at |> is_nil
-          assert job.priority == 19
+          assert job.priority == 0
           assert job.term == {Rihanna.Mocks.MockJob, :arg}
 
           assert {:ok, _} = Rihanna.delete(job.id)
@@ -149,7 +149,7 @@ defmodule RihannaTest do
         assert job.due_at |> is_nil
         assert job.fail_reason |> is_nil
         assert job.failed_at |> is_nil
-        assert job.priority == 19
+        assert job.priority == 0
         assert job.term == {Rihanna.Mocks.MockJob, :arg}
 
         assert {:ok, _} = Rihanna.delete(job.id)

--- a/test/rihanna_test.exs
+++ b/test/rihanna_test.exs
@@ -20,6 +20,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
+      assert job.priority == 19
       assert job.term == @term
     end
 
@@ -33,6 +34,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
+      assert job.priority == 19
       assert job.term == @term
     end
 
@@ -67,6 +69,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
+      assert job.priority == 19
       assert job.term == {Rihanna.Mocks.MockJob, :arg}
     end
 
@@ -80,6 +83,7 @@ defmodule RihannaTest do
       assert job.due_at |> is_nil
       assert job.fail_reason |> is_nil
       assert job.failed_at |> is_nil
+      assert job.priority == 19
       assert job.term == {Rihanna.Mocks.MockJob, :arg}
     end
 
@@ -122,6 +126,7 @@ defmodule RihannaTest do
           assert job.due_at |> is_nil
           assert job.fail_reason |> is_nil
           assert job.failed_at |> is_nil
+          assert job.priority == 19
           assert job.term == {Rihanna.Mocks.MockJob, :arg}
 
           assert {:ok, _} = Rihanna.delete(job.id)
@@ -144,6 +149,7 @@ defmodule RihannaTest do
         assert job.due_at |> is_nil
         assert job.fail_reason |> is_nil
         assert job.failed_at |> is_nil
+        assert job.priority == 19
         assert job.term == {Rihanna.Mocks.MockJob, :arg}
 
         assert {:ok, _} = Rihanna.delete(job.id)
@@ -166,6 +172,7 @@ defmodule RihannaTest do
                 fail_reason: nil,
                 failed_at: nil,
                 id: 1,
+                priority: 19,
                 term: {Rihanna.Mocks.MockJob, :arg}
               }} = Rihanna.delete(job.id)
 

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -97,7 +97,7 @@ defmodule TestHelper do
         pg,
         """
           INSERT INTO "rihanna_jobs" (term, enqueued_at, priority)
-          VALUES ($1, '2018-01-01', -19)
+          VALUES ($1, '2018-01-01', 1)
           RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
         """,
         [:erlang.term_to_binary(@test_term)]

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -61,7 +61,7 @@ defmodule TestHelper do
       exec.(
         conn,
         """
-        SELECT id, term, enqueued_at, due_at, failed_at, fail_reason FROM "rihanna_jobs" WHERE id = $1
+        SELECT id, term, enqueued_at, due_at, failed_at, fail_reason, priority FROM "rihanna_jobs" WHERE id = $1
         """,
         [id]
       )
@@ -81,7 +81,24 @@ defmodule TestHelper do
         """
           INSERT INTO "rihanna_jobs" (term, enqueued_at)
           VALUES ($1, '2018-01-01')
-          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason
+          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
+        """,
+        [:erlang.term_to_binary(@test_term)]
+      )
+
+    [job] = Rihanna.Job.from_sql(result.rows)
+
+    job
+  end
+
+  def insert_job(pg, :ready_to_run_highest_priority) do
+    result =
+      Postgrex.query!(
+        pg,
+        """
+          INSERT INTO "rihanna_jobs" (term, enqueued_at, priority)
+          VALUES ($1, '2018-01-01', -19)
+          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
         """,
         [:erlang.term_to_binary(@test_term)]
       )
@@ -99,7 +116,7 @@ defmodule TestHelper do
         """
           INSERT INTO "rihanna_jobs" (term, enqueued_at, due_at)
           VALUES ($1, '2018-01-01', now() + interval '1 minute')
-          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason
+          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
         """,
         [:erlang.term_to_binary(@test_term)]
       )
@@ -117,7 +134,7 @@ defmodule TestHelper do
         """
           INSERT INTO "rihanna_jobs" (term, enqueued_at, due_at)
           VALUES ($1, '2018-01-01', now())
-          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason
+          RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
         """,
         [:erlang.term_to_binary(@test_term)]
       )
@@ -139,7 +156,7 @@ defmodule TestHelper do
           fail_reason
         )
         VALUES ($1, '2018-01-01', '2018-01-02', 'Kaboom!')
-        RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason
+        RETURNING id, term, enqueued_at, due_at, failed_at, fail_reason, priority
         """,
         [:erlang.term_to_binary(@test_term)]
       )


### PR DESCRIPTION
This PR implements the feature defined in #56. It adds a `priority` method and serialised field which can be overridden by the user to define how high (or low) a job priority is. This allows higher priority jobs to be scheduled ahead of lower priority jobs.