### PR TITLE
Add mix tasks to setup database without Ecto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,11 @@ To do this, add a local.exs config file with your changes to the config.
 
 You can use the config.exs file as a template for what might go in there.
 
-Next, you'll need a database for Rihanna to store its jobs in.
+Next, you need to setup the database. Run `mix rihanna.setup` (an alias for `mix do rihanna.create, rihanna.migrate`). This command will create the database defined in your config :rihanna, :postgrex, :database and run the necessary migrations (table to store its jobs, etc.).
+
+> Make sure there is a database "postgres" accessible if you want to run the rihanna.create and rihanna.drop tasks. It's needed when creating or deleting the Rihanna database.
+
+Alternatively, you can create the database manually:
 
 If you were using psql to interact with your database:
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,9 @@ but if you are using a different library, please configure `Postgrex` to use it.
 
 #### Step 2 - migrate the database
 
-Add a migration to create your jobs table.
+Make sure you dependencies are compiled with `mix deps.compile`.
 
-Rihanna stores jobs in a table in your database. The default table name is "rihanna_jobs".
-
-To create the table yourself take a look at the docs for [Rihanna.Migration](https://hexdocs.pm/rihanna/Rihanna.Migration.html#content).
+Run `mix rihanna.migrate` to create the table that Rihanna uses to store jobs ("rihanna_jobs" by default) and others necessary objects.
 
 #### Step 3 - boot the supervisor
 

--- a/lib/mix/tasks/rihanna.create.ex
+++ b/lib/mix/tasks/rihanna.create.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Tasks.Rihanna.Create do
+  use Mix.Task
+
+  @maintenance_database "postgres"
+
+  @shortdoc "Create the Rihanna database"
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:postgrex)
+
+    db = Application.get_env(:rihanna, :postgrex)
+
+    {:ok, pg} =
+      db
+      |> Keyword.put(:database, @maintenance_database)
+      |> Postgrex.start_link()
+
+    case Postgrex.query(pg, "CREATE DATABASE #{db[:database]};", []) do
+      {:ok, _} ->
+        Mix.shell().info("Created database #{db[:database]}")
+
+      {:error, error} ->
+        Mix.raise("#{error.postgres.code}: #{error.postgres.message}")
+    end
+  end
+end

--- a/lib/mix/tasks/rihanna.drop.ex
+++ b/lib/mix/tasks/rihanna.drop.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Tasks.Rihanna.Drop do
+  use Mix.Task
+
+  @maintenance_database "postgres"
+
+  @shortdoc "Drop the Rihanna database"
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:postgrex)
+
+    db = Application.get_env(:rihanna, :postgrex)
+
+    {:ok, pg} =
+      db
+      |> Keyword.put(:database, @maintenance_database)
+      |> Postgrex.start_link()
+
+    case Postgrex.query(pg, "DROP DATABASE #{db[:database]};", []) do
+      {:ok, _} ->
+        Mix.shell().info("Dropped database #{db[:database]}")
+
+      {:error, error} ->
+        Mix.raise("#{error.postgres.code}: #{error.postgres.message}")
+    end
+  end
+end

--- a/lib/mix/tasks/rihanna.migrate.ex
+++ b/lib/mix/tasks/rihanna.migrate.ex
@@ -1,0 +1,19 @@
+defmodule Mix.Tasks.Rihanna.Migrate do
+  use Mix.Task
+
+  @shortdoc "Runs the necessary Rihanna migrations"
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:postgrex)
+
+    db = Application.get_env(:rihanna, :postgrex)
+    {:ok, pg} = Postgrex.start_link(db)
+
+    for stmt <- Rihanna.Migration.statements() do
+      with {:error, error} <- Postgrex.query(pg, stmt, []) do
+        Mix.raise("#{error.postgres.code}: #{error.postgres.message}")
+      end
+    end
+
+    Mix.shell().info("Migrated database #{db[:database]}")
+  end
+end

--- a/lib/mix/tasks/rihanna.upgrade.ex
+++ b/lib/mix/tasks/rihanna.upgrade.ex
@@ -1,0 +1,19 @@
+defmodule Mix.Tasks.Rihanna.Upgrade do
+  use Mix.Task
+
+  @shortdoc "Upgrade an existing Rihanna database"
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:postgrex)
+
+    db = Application.get_env(:rihanna, :postgrex)
+    {:ok, pg} = Postgrex.start_link(db)
+
+    for stmt <- Rihanna.Migration.statements() do
+      with {:error, error} <- Postgrex.query(pg, stmt, []) do
+        Mix.raise("#{error.postgres.code}: #{error.postgres.message}")
+      end
+    end
+
+    Mix.shell().info("Upgraded database #{db[:database]}")
+  end
+end

--- a/lib/rihanna/migration.ex
+++ b/lib/rihanna/migration.ex
@@ -25,8 +25,7 @@ defmodule Rihanna.Migration do
 
   #### Without Ecto
 
-  Ecto is not required to run Rihanna. If you want to create the table yourself,
-  without Ecto, take a look at either `statements/0` or `sql/0`.
+  Ecto is not required to run Rihanna. Run `mix rihanna.migrate` to setup your database.
 
   """
 

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -23,8 +23,7 @@ defmodule Rihanna.Migration.Upgrade do
 
   #### Without Ecto
 
-  Ecto is not required to run Rihanna. If you want to upgrade the table yourself,
-  without Ecto, take a look at either `statements/0` or `sql/0`.
+  Ecto is not required to run Rihanna. Run `mix rihanna.upgrade` to upgrade your database.
 
   """
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Rihanna.MixProject do
       dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"],
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
+      aliases: aliases(),
       docs: [
         main: "Rihanna",
         extras: ["README.md"]
@@ -63,5 +64,9 @@ defmodule Rihanna.MixProject do
       maintainers: ["sampdavies@gmail.com", "louis@lpil.uk"],
       links: %{"GitHub" => "https://github.com/samphilipd/rihanna"}
     ]
+  end
+
+  defp aliases() do
+    ["rihanna.setup": ["rihanna.create", "rihanna.migrate"]]
   end
 end


### PR DESCRIPTION
This PR tries to simplify the database setup needed by Rihanna by providing an easy way to run the necessary migrations instead of [asking](https://github.com/samphilipd/rihanna/blob/512ec2e91c3cf6467fe94ab1888ead2d29800022/lib/rihanna/migration.ex#L26) users who are not using Ecto to do it manually.

Introduces the following changes:
 - four new [mix tasks](https://hexdocs.pm/mix/Mix.Task.html) mimicking the Ecto database setup tasks;
 - an alias `rihanna.setup` (`mix do rihanna.create, rihanna.migrate`);
 - updates `CONTRIBUTING.md`
 - updates documentation

```sh
$ mix help --search rihanna
mix rihanna.create  # Create the Rihanna database
mix rihanna.drop    # Drop the Rihanna database
mix rihanna.migrate # Runs the necessary Rihanna migrations
mix rihanna.setup   # Alias defined in mix.exs
mix rihanna.upgrade # Upgrade an existing Rihanna database
```
