### PR TITLE
Order by due_at

### DIFF
--- a/docs/upgrading_v2.md
+++ b/docs/upgrading_v2.md
@@ -38,7 +38,7 @@ This options should only be attempted if you feel VERY comfortable with SQL
 
 ```
 ALTER TABLE rihanna_jobs ADD COLUMN priority integer;
-CREATE INDEX CONCURRENTLY rihanna_jobs_priority_enqueued_at_id ON rihanna_jobs (priority ASC, enqueued_at ASC, id ASC);
+CREATE INDEX CONCURRENTLY rihanna_jobs_locking_index ON rihanna_jobs (priority ASC, due_at ASC, enqueued_at ASC, id ASC);
 ```
 
 2. Upgrade your code to use Rihanna v2

--- a/lib/rihanna/migration/upgrade.ex
+++ b/lib/rihanna/migration/upgrade.ex
@@ -80,7 +80,8 @@ defmodule Rihanna.Migration.Upgrade do
       DO $$
           BEGIN
               DROP INDEX IF EXISTS rihanna_jobs_priority_enqueued_at_id;
-              CREATE INDEX IF NOT EXISTS rihanna_jobs_enqueued_at_id ON rihanna_jobs (enqueued_at ASC, id ASC);
+              DROP INDEX IF EXISTS #{table_name}_locking_index;
+              CREATE INDEX IF NOT EXISTS #{table_name}_locking_index ON #{table_name} (priority ASC, due_at ASC, enqueued_at ASC, id ASC);
           END;
       $$
       """
@@ -139,7 +140,9 @@ defmodule Rihanna.Migration.Upgrade do
       DO $$
         BEGIN
           DROP INDEX IF EXISTS #{table_name}_enqueued_at_id;
-          CREATE INDEX IF NOT EXISTS #{table_name}_priority_enqueued_at_id ON #{table_name} (priority ASC, enqueued_at ASC, id ASC);
+          DROP INDEX IF EXISTS #{table_name}_priority_enqueued_at_id;
+          DROP INDEX IF EXISTS #{table_name}_locking_index;
+          CREATE INDEX IF NOT EXISTS #{table_name}_locking_index ON #{table_name} (priority ASC, due_at ASC, enqueued_at ASC, id ASC);
         END;
       $$
       """


### PR DESCRIPTION
Currently, a job enqueued first will run first regardless of the order of the due_at, which could, given enough work allow a single job to run multiple times (in the case of retries) before another job that was enqueued originally after, but due before the retried jobs.

This PR is complicated by the need to again change the locking index to retain performance levels on the job lock query. The DB upgrade is not _required_ to function, but there may be performance degradation without it.

Resolves #86 